### PR TITLE
Jest Action: Only run tests related to changed JS files

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,9 @@ inputs:
   check-run-subtitle:
     required: false
     description: 'A subtitle to add to the check run when annotations are passed back to avoid overwriting each other'
+  find-related-tests:
+    required: false
+    description: 'Set to 1 to make it so that only related test files are run, not all tests.'
 branding:
   icon: check-circle
   color: red


### PR DESCRIPTION
This ensures that we don't run Jest if there are no changes to JS files. Additionally, it will make it so tha we only run test files that are related to changes that were made. If a test file was changed then that will be run - and if anon-test file was changed then it, and anything that imports it, will have its test files run.

Issue: none

Test plan:
Will this have a negative impact on the mobile repo? Are they expecting to run all tests all the time? It will definitely help to improve performance!