### PR TITLE
Add more logging to jest-action

### DIFF
--- a/jest.js
+++ b/jest.js
@@ -65,8 +65,8 @@ async function run() {
     /* flow-uncovered-block */
     // Log which files are being tested by jest.
     const cwd = process.cwd();
-    core.startGroup('Running eslint on the following files:');
-    for (const file of files) {
+    core.startGroup('Running jest on the following files:');
+    for (const file of jsFiles) {
         core.info(path.relative(cwd, file));
     }
     core.endGroup();

--- a/jest.js
+++ b/jest.js
@@ -1,4 +1,3 @@
-#!/usr/bin/env node
 // @flow
 
 /**
@@ -20,6 +19,7 @@ const sendReport = require('actions-utils/send-report');
 const execProm = require('actions-utils/exec-prom');
 const gitChangedFiles = require('actions-utils/git-changed-files');
 const getBaseRef = require('actions-utils/get-base-ref');
+const core = require("@actions/core"); // flow-uncovered-line
 
 const parseWithVerboseError = (text, stderr) => {
     try {
@@ -61,6 +61,16 @@ async function run() {
         console.log('No JavaScript files changed');
         return;
     }
+
+    /* flow-uncovered-block */
+    // Log which files are being tested by jest.
+    const cwd = process.cwd();
+    core.startGroup('Running eslint on the following files:');
+    for (const file of files) {
+        core.info(path.relative(cwd, file));
+    }
+    core.endGroup();
+    /* end flow-uncovered-block */
 
     // Build the Jest command
     const jestCmd = [jestBin, '--json', '--testLocationInResults', '--passWithNoTests'];
@@ -107,6 +117,14 @@ async function run() {
         await sendReport('Jest', []);
         return;
     }
+
+    /* flow-uncovered-block */
+    // Log which files are being tested by jest.
+    core.startGroup('Output from jest:');
+    core.info(JSON.stringify(data, null, 2));
+    core.endGroup();
+    /* end flow-uncovered-block */
+
     const annotations = [];
     for (const testResult of data.testResults) {
         if (testResult.status !== 'failed') {

--- a/jest.js
+++ b/jest.js
@@ -45,7 +45,7 @@ const runJest = (
         core.info(`running ${jestBin} with options ${jestOpts.join(', ')}`);
         const jest = spawn(jestBin, jestOpts, spawnOpts);
 
-        core.group('Running jest');
+        core.info('Running jest');
 
         jest.stdout.on('data', data => {
             core.info(data.toString());
@@ -61,7 +61,6 @@ const runJest = (
             if (code) {
                 core.error(`jest exited with code ${code}`);
             }
-            core.endGroup();
             resolve();
         });
     });

--- a/jest.js
+++ b/jest.js
@@ -45,8 +45,6 @@ const runJest = (
         core.info(`running ${jestBin} with options ${jestOpts.join(', ')}`);
         const jest = spawn(jestBin, jestOpts, spawnOpts);
 
-        core.info('Running jest');
-
         jest.stdout.on('data', data => {
             core.info(data.toString());
         });
@@ -58,9 +56,8 @@ const runJest = (
         });
 
         jest.on('close', code => {
-            if (code) {
-                core.error(`jest exited with code ${code}`);
-            }
+            // Jest will exit with a non-zero exit code if any test fails.
+            // This is normal so we don't bother logging error code.
             resolve();
         });
     });
@@ -121,7 +118,9 @@ async function run() {
     }
 
     try {
-        await runJest(jestBin, jestOpts, {cwd: workingDirectory});
+        await core.group("Running jest", async () => {
+            await runJest(jestBin, jestOpts, {cwd: workingDirectory});
+        });
     } catch (err) {
         core.error('An error occurred trying to run jest');
         core.error(err);
@@ -174,8 +173,8 @@ async function run() {
                 });
             }
         }
+        // All test failures have no location data
         if (!hadLocation) {
-            console.log('no location,');
             annotations.push({
                 path,
                 start: {line: 1, column: 0},

--- a/jest.js
+++ b/jest.js
@@ -42,7 +42,7 @@ const runJest = (
 ) /*: Promise<void> */ => {
     /* flow-uncovered-block */
     return new Promise((resolve, reject) => {
-        core.info(`running ${jestBin} with options ${jestOpts.join(', ')}`);
+        core.info(`running ${jestBin} ${jestOpts.join(' ')}`);
         const jest = spawn(jestBin, jestOpts, spawnOpts);
 
         jest.stdout.on('data', data => {
@@ -91,16 +91,6 @@ async function run() {
         core.info('No JavaScript files changed'); // flow-uncovered-line
         return;
     }
-
-    /* flow-uncovered-block */
-    // Log which files are being tested by jest.
-    const cwd = process.cwd();
-    core.startGroup('Running jest on the following files:');
-    for (const file of jsFiles) {
-        core.info(path.relative(cwd, file));
-    }
-    core.endGroup();
-    /* end flow-uncovered-block */
 
     const tmpObj = tmp.fileSync();
 

--- a/jest.js
+++ b/jest.js
@@ -52,6 +52,7 @@ const runJest = (jestBin /*: string */, jestOpts /*: Array<string> */) /*: Promi
         jest.on('close', code => {
             if (code) {
                 core.error(`jest exited with code ${code}`);
+                core.endGroup();
                 reject();
             }
             resolve();
@@ -62,10 +63,9 @@ const runJest = (jestBin /*: string */, jestOpts /*: Array<string> */) /*: Promi
                 core.error(`jest exited with code ${code}`);
             }
             core.error(`stdio are not yet closed`);
+            core.endGroup();
             reject();
         });
-
-        core.endGroup();
     });
 };
 
@@ -122,7 +122,12 @@ async function run() {
         jestOpts.push('--findRelatedTests', ...jsFiles);
     }
 
-    await runJest(jestBin, jestOpts);
+    try {
+        await runJest(jestBin, jestOpts);
+    } catch (err) {
+        core.error(err);
+        process.exit(1);
+    }
 
     console.log(`Parsing json output from jest...`);
 

--- a/jest.js
+++ b/jest.js
@@ -96,15 +96,15 @@ async function run() {
         cwd: workingDirectory || '.',
     });
 
-    if (stdout === null || stdout === '') {
-        console.error(`\nThere was an error running jest${stderr ? ':\n\n' + stderr : ''}`);
-        process.exit(1);
-        return;
-    }
+    // if (stdout === null || stdout === '') {
+    //     console.error(`\nThere was an error running jest${stderr ? ':\n\n' + stderr : ''}`);
+    //     process.exit(1);
+    //     return;
+    // }
 
     // TODO: stream output from jest
     core.group("Jest output");
-    core.info(stdout);
+    core.info(stderr); // jest outputs to stderr by default, TODO: link to GitHub ticket
     core.endGroup();
 
     console.log(`Parsing json output from jest...`);

--- a/jest.js
+++ b/jest.js
@@ -38,7 +38,7 @@ const parseWithVerboseError = (text /*: string */) => {
 const runJest = (
     jestBin /*: string */,
     jestOpts /*: Array<string> */,
-    spawnOpts /*: any */,
+    spawnOpts /*: any */, // flow-uncovered-line
 ) /*: Promise<void> */ => {
     /* flow-uncovered-block */
     return new Promise((resolve, reject) => {
@@ -70,9 +70,11 @@ async function run() {
     const subtitle = process.env['INPUT_CHECK-RUN-SUBTITLE'];
     const findRelatedTests = process.env['INPUT_FIND-RELATED-TESTS'];
     if (!jestBin) {
+        /* flow-uncovered-block */
         core.info(
             `You need to have jest installed, and pass in the the jest binary via the variable 'jest-bin'.`,
         );
+        /* end flow-uncovered-block */
         process.exit(1);
         return;
     }
@@ -92,11 +94,11 @@ async function run() {
         return;
     }
 
-    const tmpObj = tmp.fileSync();
+    const tmpObj = tmp.fileSync(); // flow-uncovered-line
 
     const jestOpts = [
         '--json',
-        `--outputFile=${tmpObj.name}`,
+        `--outputFile=${tmpObj.name}`, // flow-uncovered-line
         '--testLocationInResults',
         '--passWithNoTests',
     ];
@@ -107,6 +109,7 @@ async function run() {
         jestOpts.push('--findRelatedTests', ...jsFiles);
     }
 
+    /* flow-uncovered-block */
     try {
         await core.group("Running jest", async () => {
             await runJest(jestBin, jestOpts, {cwd: workingDirectory});
@@ -116,10 +119,11 @@ async function run() {
         core.error(err);
         process.exit(1);
     }
+    /* end flow-uncovered-block */
 
-    core.info('Parsing json output from jest');
+    core.info('Parsing json output from jest'); // flow-uncovered-line
 
-    const output = fs.readFileSync(tmpObj.name, 'utf-8');
+    const output = fs.readFileSync(tmpObj.name, 'utf-8'); // flow-uncovered-line
 
     /* flow-uncovered-block */
     const data /*:{

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "prettier-eslint-cli": "^5.0.0"
     },
     "dependencies": {
+        "@actions/core": "^1.2.7",
         "jest": "^26.0.1"
     }
 }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     },
     "dependencies": {
         "@actions/core": "^1.2.7",
-        "jest": "^26.0.1"
+        "jest": "^26.0.1",
+        "tmp": "^0.2.1"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@actions/core@^1.2.7":
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.2.7.tgz#594f8c45b213f0146e4be7eda8ae5cf4e198e5ab"
+  integrity sha512-kzLFD5BgEvq6ubcxdgPbRKGD2Qrgya/5j+wh4LZzqT915I0V3rED+MvjH6NXghbvk1MXknpNNQ3uKjXSEN00Ig==
+
 "@actions/github@^2.1.1":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@actions/github/-/github-2.1.1.tgz#bcabedff598196d953f58ba750d5e75549a75142"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5429,6 +5429,13 @@ tmp@^0.0.33:
   dependencies:
     os-tmpdir "~1.0.2"
 
+tmp@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
+  integrity sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==
+  dependencies:
+    rimraf "^3.0.0"
+
 tmpl@1.0.x:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"


### PR DESCRIPTION
## Summary:
The action now logs:
- what jest command is being running
- the output of jest is streamed as jest is running

The latter has the benefits of letting devs know that jest is doing stuff as well as showing all test failures (there's a limited number of annotations that we can show in a PR).

Issue: FEI-3429

## Test plan:
- look at the logs for "Run Jest" in https://github.com/Khan/webapp/pull/574/checks?check_run_id=2383504871

Output from example test run:
<img width="833" alt="Screen Shot 2021-04-19 at 3 32 11 PM" src="https://user-images.githubusercontent.com/1044413/115292805-747a5180-a124-11eb-8cf1-fd8e6bde33fd.png">
