### PR TITLE
Add "run-all-if-changed" parameter, to allow re-triggering all tests if jest.config.js or package.json changes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,9 @@ inputs:
   find-related-tests:
     required: false
     description: 'Set to 1 to make it so that only related test files are run, not all tests.'
+  run-all-if-changed:
+    required: false
+    description: 'Comma-separated list of files which, if changed, trigger a re-check of all files, ignoring find-related-tests'
 branding:
   icon: check-circle
   color: red

--- a/jest.js
+++ b/jest.js
@@ -64,11 +64,19 @@ const runJest = (
     /* end flow-uncovered-block */
 };
 
+const parseList = (text) /*: Array<string>*/ => {
+    if (!text || !text.length) {
+        return [];
+    }
+    return text.split(',');
+};
+
 async function run() {
     const jestBin = process.env['INPUT_JEST-BIN'];
     const workingDirectory = process.env['INPUT_CUSTOM-WORKING-DIRECTORY'] || '.';
     const subtitle = process.env['INPUT_CHECK-RUN-SUBTITLE'];
     const findRelatedTests = process.env['INPUT_FIND-RELATED-TESTS'];
+    const runAllIfChanged = parseList(process.env['INPUT_RUN-ALL-IF-CHANGED']);
     if (!jestBin) {
         /* flow-uncovered-block */
         core.info(
@@ -86,10 +94,15 @@ async function run() {
         return;
     }
 
+    const current = path.resolve(workingDirectory);
     const files = await gitChangedFiles(baseRef, workingDirectory);
+    const shouldRunAll = runAllIfChanged.some(name =>
+        files.some(file => path.relative(current, file) === name),
+    );
+
     const validExt = ['.js', '.jsx', '.mjs', '.ts', '.tsx'];
     const jsFiles = files.filter(file => validExt.includes(path.extname(file)));
-    if (!jsFiles.length) {
+    if (!jsFiles.length && !shouldRunAll) {
         core.info('No JavaScript files changed'); // flow-uncovered-line
         return;
     }
@@ -105,7 +118,7 @@ async function run() {
 
     // If we only want related tests, then we explicitly specify that and
     // include all of the files that are to be run.
-    if (findRelatedTests) {
+    if (findRelatedTests && !shouldRunAll) {
         jestOpts.push('--findRelatedTests', ...jsFiles);
     }
 


### PR DESCRIPTION
## Summary:
This allows us to specify in the repo which files would trigger a full recheck.

Jira: https://khanacademy.atlassian.net/browse/FEI-3520

## Test plan:
🤞 try using it in webapp