### PR TITLE
Allow folders to be specified in run-all-if-changed

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
     description: 'Set to 1 to make it so that only related test files are run, not all tests.'
   run-all-if-changed:
     required: false
-    description: 'Comma-separated list of files which, if changed, trigger a re-check of all files, ignoring find-related-tests'
+    description: 'Comma-separated list of files which, if changed, trigger a re-check of all files, ignoring find-related-tests. Directories can be specified with a trailing /, in which case all descendents of that directory would trigger a full re-check.'
 branding:
   icon: check-circle
   color: red

--- a/jest.js
+++ b/jest.js
@@ -101,7 +101,9 @@ async function run() {
 
     const current = path.resolve(workingDirectory);
     const files = await gitChangedFiles(baseRef, workingDirectory);
-    const relativeFiles = files.map(absPath => path.relative(current, absPath));
+    const relativeFiles /*: Array<string> */ = files.map(absPath =>
+        path.relative(current, absPath),
+    );
     const shouldRunAll = runAllIfChanged.some(needle =>
         // If it ends with a `/`, it's a directory, and we flag all descendents.
         needle.endsWith('/')


### PR DESCRIPTION
## Summary:
Our jest config in webapp has a bunch of files, and it would be nice to just specify the directory they live in.

Issue: https://khanacademy.atlassian.net/browse/FEI-3520

## Test plan:
I'll use it over here https://github.com/Khan/webapp/pull/1343